### PR TITLE
feature: Add support for proxyImagePullSecrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,17 @@ spec:
 
   ...
 ```
+
+If you want to pull the proxyImage from a private registry you can set the `proxyImagePullSecret` config.
+```yaml
+cat <<EOF | kubectl create -f -
+apiVersion: "jenkins.io/v1"
+kind: "SSO"
+metadata:
+  name: "sso-golang-http"
+  namespace: jx-staging
+spec:
+  proxyImagePullSecret: "private-registry-secret"
+
+  ...
+```

--- a/pkg/apis/jenkins.io/v1/types.go
+++ b/pkg/apis/jenkins.io/v1/types.go
@@ -36,6 +36,8 @@ type SSOSpec struct {
 	ProxyImage string `json:"proxyImage,omitempty"`
 	// Docker image tag for oauth2_proxy
 	ProxyImageTag string `json:"proxyImageTag,omitempty"`
+	// Docker image PullSecret for oauth2_proxy
+	ProxyImagePullSecret string `json:"proxyImagePullSecret,omitempty"`
 	// Resource requirements for oauth2_proxy pod
 	ProxyResources v1.ResourceRequirements `json:"proxyResources,omitempty"`
 	// Indicate if the access token should be forwarded to the upstream service

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -156,6 +156,9 @@ func Deploy(sso *apiv1.SSO, oidcClient *api.Client, cookieSecret string) (*Proxy
 					},
 				},
 			}},
+			ImagePullSecrets: []v1.LocalObjectReference{
+				{sso.Spec.ProxyImagePullSecret},
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR adds the `proxyImagePullSecret` configuration option to the SSO operator.

Using a private registry to pull the proxy Image from, requires to set a pullSecret. This was not possible because the sso configuration could set a proxyImage and a proxyImageVersion, but had no means of setting a pullSecret.

In the case of the pullSecret not being set, it will just fill it with a blank value and k8s will apply it anyway